### PR TITLE
PHP 5.4 Strict Standards

### DIFF
--- a/library/DrSlump/Spec/RunHelper.php
+++ b/library/DrSlump/Spec/RunHelper.php
@@ -139,7 +139,7 @@ class RunHelper
                     \DrSlump\Spec::getRunHelper()->disposeTest(\$this);
                 }
 
-                function onNotSuccessfulTest(\$e) {
+                function onNotSuccessfulTest(Exeception \$e) {
                     \$e = \DrSlump\Spec::getRunHelper()->onNotSuccessfulTest(\$this, \$e);
                     parent::onNotSuccessfulTest(\$e);
                 }


### PR DESCRIPTION
Found this PHP 5.4 Strict Standards error.

There are a couple more, but they are little beyond me at this point of time.
